### PR TITLE
feat: adding variables support

### DIFF
--- a/examples/webpack/index.js
+++ b/examples/webpack/index.js
@@ -30,8 +30,10 @@ const data = {
 //   }
 // `;
 
-const user = dinoql(data)(Form);
+const variables = {
+  id: "200"
+};
+
+const user = dinoql(data, { variables })(Form);
 console.log(user);
-// { friends: [ { name: 'Kátia', id: '300', age: 10 } ],
-//   users: [ { name: 'Victor Igor' }, { name: 'Kant Jonas' } ],
-//   products: [] }
+// { products: [ { test: 0 } ], users: [ { name: 'Kant Jonas' } ] }

--- a/examples/webpack/query.graphql
+++ b/examples/webpack/query.graphql
@@ -1,5 +1,5 @@
 fragment queryOne on Query {
-  users {
+  users(id: $id) {
     name
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dinoql",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "A query language for JavaScript Objects using GraphQL syntax.",
   "main": "dist/dinoql.min.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ function dinoql(data, options = { keep: false }) {
       return memo[dataIndex];
     }
 
-    const ast = parser(query);
+    const ast = parser(query, options);
     const body = _.path(['definitions', 0], ast);
     const bodyName = _.ast.getName(body);
 

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,14 +1,15 @@
 const _ = require('./utils');
 const { parse } = require('graphql/language/parser');
 const fragments = require('./fragments');
+const visitAST = require('./visit');
 /**
  * @param {string} code - The code to parse
  * @returns {object} Returns an ast from code
  */
-function parser(code) {
+function parser(code, options) {
   const query = _.prop(0, code);
   if(!_.is(String, query)) {
-    return fragments.mergeFragments(code)
+    return visitAST(fragments.mergeFragments(code), options)
   }
 
   const ql = ` 
@@ -17,7 +18,7 @@ function parser(code) {
     }
   `;
 
-  return parse(ql);
+  return visitAST(parse(ql), options);
 }
 
 module.exports = parser;

--- a/src/visit.js
+++ b/src/visit.js
@@ -1,0 +1,15 @@
+const { visit } = require('graphql/language/visitor');
+const _ = require('./utils');
+
+function visitAST(ast, options) {
+  const variables = _.prop('variables', options);
+  return visit(ast, {
+    Variable(node) {
+      const nodeName = _.ast.getName(node);
+      const value = _.prop(nodeName, variables);
+      return { value }
+    }
+  });
+}
+
+module.exports = visitAST;

--- a/tests/dql.test.js
+++ b/tests/dql.test.js
@@ -302,5 +302,25 @@ describe('[dql] { keep: false }', () => {
 
     expect(value).toEqual(dataChanged);
   });
+
+  test('should works variables', () => {
+    const newData = {
+      users: [{ id: "200", name: 'Vic' }, { id: "300", name: 'Paul' }]
+    };
+
+    const variables = {
+      id: "200"
+    };
+
+    const value = dql(newData, { variables })`
+      users(id: $id)
+    `;
+
+    const dataExpected = {
+      users: [{ id: '200', name: 'Vic'}]
+    };
+
+    expect(value).toEqual(dataExpected);
+  });
 });
 


### PR DESCRIPTION
Adding variables support:

```js
const data = {
  users: [{
    name: 'Victor Igor',
    id: "100",
    age: 40
  }, {
    name: 'Kant Jonas',
    id: "200",
    age: 35
  }],	
};

const variables = {
  id: "200"
};

const value = dinoql(data, { variables })`
  users(id: $id) {
	name
  }
`
// { users: [{ name: 'Kant Jonas' }] }
```