### PR TITLE
New `resolvers` functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ A customizable GraphQL style query language for interacting with JavaScript obje
     - [Parse to array](#parse-to-array)
     - [First](#first)
     - [Last](#last)
+    - [Get Prop](#get-prop)
+    - [get Path](#get-path)
+    
   - [Building your own resolver](#building-your-own-resolver)
   - [Custom options](#custom-options)
     - [Keep structure](#keep-structure)
@@ -382,6 +385,110 @@ const users = dinoql(data)`
 `
 
 console.log(users)  //{ users: { name: 'Kant Jonas' } }
+```
+
+### Get Prop
+
+```js
+import dinoql from 'dinoql'
+
+const newData = {
+  requests: {
+    users: { id: 10, name: 'Victor Fellype' },
+    information: { 
+      title: { text: 'my title' }, 
+      description: { text: 'my description' } 
+    }
+  }
+};
+```
+
+old method 
+
+```js
+const data = dinoql(newData)`
+  requests {
+    users {
+      name
+    }
+    information {
+      title {
+        title: text
+      }
+      description {
+        description: text
+      }
+    }
+  }
+`
+```
+
+with getProp
+
+```js
+const data = dinoql(newData)`
+  requests {
+    users(getProp: name)
+    information {
+      title(getProp: text)
+      description(getProp: text)
+    }
+  }
+`
+
+console.log(data) // { users: 'Victor Fellype', title: 'my title', description: 'my description' }
+```
+
+
+### Get Path
+
+```js
+import dinoql from 'dinoql'
+
+const newData = {
+  requests: {
+    cms: {
+      footer_data: {
+        social_networks: [
+          { name: 'facebook', url: 'facebook.com' },
+          { name: 'instagram', url: 'instagram.com' }
+        ]
+      }
+    }
+  }
+};
+```
+
+old method 
+
+```js
+const data = dinoql(newData)`
+  requests {
+    cms {
+      footer_data {
+        social_networks
+      }
+    }
+  }
+`
+```
+
+with getPath
+
+```js
+const socialNetworks = dinoql(newData)`
+  requests(getPath: "cms.footer_data.social_networks")
+`
+
+console.log(socialNetworks) 
+/* 
+  { 
+    requests: [ 
+      { name: 'facebook', url: 'facebook.com' }, 
+      { name: 'instagram', url: 'instagram.com' }
+    ]
+  }
+*/
 ```
 
 ### Building your own resolver

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A customizable GraphQL style query language for interacting with JavaScript obje
     - [First](#first)
     - [Last](#last)
     - [Get Prop](#get-prop)
-    - [get Path](#get-path)
+    - [Get Path](#get-path)
     
   - [Building your own resolver](#building-your-own-resolver)
   - [Custom options](#custom-options)

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -123,16 +123,35 @@ const merge = (value, right) => {
   return value;
 };
 
+/**
+ * @param {*} obj - The object to search.
+ * @param {*} right - A prop.
+ * @returns {*} returns the value of the passed prop right inside obj.
+ */
+const getProp = (obj, right) => _.prop(right, obj);
+
+/**
+ * @param {*} value - the object to search.
+ * @param {*} right - A path.
+ * @returns {*} returns the value of the passed path right inside obj.
+ */
+const getPath = (obj, right) => {
+	const path = right.split('.');
+	return _.path(path, obj);
+};
+
 module.exports = {
-  filterKey,
-  orderBy,
-  first,
   last,
-  toNumber,
-  defaultValue,
-  toArray,
-  getObjectValues,
+  first,
   merge,
   unless,
+  orderBy,
+  toArray,
+  getProp,
+  getPath,
+  toNumber,
+  filterKey,
   if: condIf,
+  defaultValue,
+  getObjectValues
 };

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -319,7 +319,7 @@ describe('[dql] resolvers', () => {
 
       const data = dql(newData)`
         requests {
-          users(getProp: id)
+          users(getProp: name)
           information {
             title(getProp: text)
             description(getProp: text)
@@ -327,7 +327,7 @@ describe('[dql] resolvers', () => {
         }
       `
 
-      expect(data).toEqual({ users: 10, title: 'my title', description: 'my description' });
+      expect(data).toEqual({ users: 'Victor Fellype', title: 'my title', description: 'my description' });
     });
 
     test('should return a void obj {}', () => {

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -306,7 +306,7 @@ describe('[dql] resolvers', () => {
   });
 
   describe('[getProp]', () => {
-    test('should return the obj { users: 10, title: "my title", description: "my description" }', () => {
+    test('should return the obj with various data', () => {
       const newData = {
         requests: {
           users: { id: 10, name: 'Victor Fellype' },
@@ -330,7 +330,7 @@ describe('[dql] resolvers', () => {
       expect(data).toEqual({ users: 10, title: 'my title', description: 'my description' });
     });
 
-    test('should return a undefined', () => {
+    test('should return a void obj {}', () => {
       const newData = {
         requests: {
           users: { name: 'Victor Fellype' },
@@ -348,7 +348,7 @@ describe('[dql] resolvers', () => {
   });
 
   describe('[getPath]', () => {
-    test('should return ', () => {
+    test('should return a obj with one array and multiples objs', () => {
       const newData = {
         requests: {
           cms: {

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -347,5 +347,33 @@ describe('[dql] resolvers', () => {
     });
   });
 
+  describe('[getPath]', () => {
+    test('should return ', () => {
+      const newData = {
+        requests: {
+          cms: {
+            footer_data: {
+              social_networks: [
+                { name: 'facebook', url: 'facebook.com' },
+                { name: 'instagram', url: 'instagram.com' }
+              ]
+            }
+          }
+        }
+      };
+
+      const socialNetworks = dql(newData)`
+        requests(getPath: "cms.footer_data.social_networks")
+      `
+
+      expect(socialNetworks).toEqual({
+        requests: [
+          { name: 'facebook', url: 'facebook.com' },
+          { name: 'instagram', url: 'instagram.com' }
+        ]
+      });
+    });
+  });
+
 });
 

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -373,6 +373,24 @@ describe('[dql] resolvers', () => {
         ]
       });
     });
+
+    test('should return a void obj {}', () => {
+      const newData = {
+        requests: {
+          cms: {
+            footer_data: {
+              media: []
+            }
+          }
+        }
+      };
+
+      const socialMedia = dql(newData)`
+        requests(getPath: "cms.footer_data.social_networks")
+      `
+
+      expect(socialMedia).toEqual({});
+    });
   });
 
 });

--- a/tests/resolvers.test.js
+++ b/tests/resolvers.test.js
@@ -304,5 +304,48 @@ describe('[dql] resolvers', () => {
       expect(value).toEqual({ users: [{ id: 10 }, { id: 20 }] })
     });
   });
+
+  describe('[getProp]', () => {
+    test('should return the obj { users: 10, title: "my title", description: "my description" }', () => {
+      const newData = {
+        requests: {
+          users: { id: 10, name: 'Victor Fellype' },
+          information: { 
+            title: { text: 'my title' }, 
+            description: { text: 'my description' } 
+          }
+        }
+      };
+
+      const data = dql(newData)`
+        requests {
+          users(getProp: id)
+          information {
+            title(getProp: text)
+            description(getProp: text)
+          }
+        }
+      `
+
+      expect(data).toEqual({ users: 10, title: 'my title', description: 'my description' });
+    });
+
+    test('should return a undefined', () => {
+      const newData = {
+        requests: {
+          users: { name: 'Victor Fellype' },
+        }
+      };
+
+      const value = dql(newData)`
+        requests {
+          users(getProp: id)
+        }
+      `
+
+      expect(value).toEqual({});
+    });
+  });
+
 });
 


### PR DESCRIPTION
Hello, here in this PR I add two functions that helped me a lot in my day to day, I think it would be very useful to already contain in dinoql.

# getProp

With `getProp` we can access object properties without having to keep repeating keys, but the main advantage is being able to keep a structure in the middle of the object (something that we can do with keep: true, but only at the top of the object)

## example

```js
const newData = {
  requests: {
    users: { id: 10, name:  { text: 'Victor  Fellype' } },
      information: { 
        title: { text: 'my title' }, 
        description: { text: 'my description' } 
     }
  }
};

const data = dql(newData)`
   requests {
     users(getProp: name)
       information {
         title(getProp: text)
         description(getProp: text)
       }
  }
`
```

com isso conseguimos evitar coisas como 

```js
const data = dql(newData)`
   requests {
     users {
        name {
           name: text
        }
     }
       information {
         title {
           title: text
        }
         description {
           description: text
         }
       }
  }
`
```

# getPath

With `getPath` we can access very deep objects in a much more friendly way

## example

```js
const newData = {
  requests: {
      cms: {
        footer_data: {
          social_networks: [
             { name: 'facebook', url: 'facebook.com' },
             { name: 'instagram', url: 'instagram.com' }
          ]
       }
     }
  }
}

const data = dinoql(newData)`
   requests(getPath: "cms.footer_data.social_networks")
`
console.log(data)
/*
  {
     requests: [
       { name: 'facebook', url: 'facebook.com' },
       { name: 'instagram', url: 'instagram.com' }
     ]
 }
*/
```

com isso podemos evitar coisas como 

```js
requests {
    cms  {
       footer_data {
         social_networks
       }
   }
}
```